### PR TITLE
Failed description

### DIFF
--- a/app.go
+++ b/app.go
@@ -56,7 +56,7 @@ func outputResults(controls *check.Controls, summary check.Summary) error {
 		}
 		fmt.Println(string(out))
 	} else {
-		util.PrettyPrint(controls, summary, noRemediations)
+		util.PrettyPrint(controls, summary, !noRemediations)
 	}
 
 	return nil

--- a/app.go
+++ b/app.go
@@ -56,7 +56,7 @@ func outputResults(controls *check.Controls, summary check.Summary) error {
 		}
 		fmt.Println(string(out))
 	} else {
-		util.PrettyPrint(controls, summary)
+		util.PrettyPrint(controls, summary, noRemediations)
 	}
 
 	return nil

--- a/cfg/17.06/definitions.yaml
+++ b/cfg/17.06/definitions.yaml
@@ -240,10 +240,10 @@ groups:
     audit: "docker network ls --quiet | xargs docker network inspect --format '{{ .Name }}: {{ .Options }}'"
     tests:
       test_items:
-      - flag: "com.docker.network.bridge.enable_icc:false"
+      - flag: "com.docker.network.bridge.enable_icc"
         compare:
-          op: has
-          value: "com.docker.network.bridge.enable_icc:false"
+          op: eq
+          value: "false"
         set: true
     remediation: |
       Run the docker in daemon mode and pass --icc=false as an argument.

--- a/cfg/17.06/definitions.yaml
+++ b/cfg/17.06/definitions.yaml
@@ -8,6 +8,7 @@ groups:
   checks:
   - id: 1.1
     description: "Ensure a separate partition for containers has been created (Scored)"
+    failed_description: "Show this if failed"
     audit: grep /var/lib/docker /etc/fstab
     tests:
       test_items:
@@ -50,6 +51,7 @@ groups:
 
   - id: 1.5
     description: "Ensure auditing is configured for the docker daemon (Scored)"
+    failed_description: "Show this if failed"
     audit: "auditctl -l | grep /usr/bin/docker"
     tests:
       test_items:
@@ -69,6 +71,7 @@ groups:
   - id: 1.6
     description: "Ensure auditing is configured for Docker files and directories - 
     /var/lib/docker (Scored)"
+    failed_description: "Show this if failed"
     audit: "auditctl -l | grep /var/lib/docker"
     tests:
       test_items:
@@ -88,6 +91,7 @@ groups:
   - id: 1.7
     description: "Ensure auditing is configured for Docker files and directories -
     /etc/docker (Scored)"
+    failed_description: "Show this if failed"
     audit: "auditctl -l | grep /etc/docker"
     tests:
       test_items:
@@ -108,6 +112,7 @@ groups:
   - id: 1.8
     description: "Ensure auditing is configured for Docker files and directories -
     docker.service (Scored)"
+    failed_description: "Show this if failed"
     audit: "auditctl -l | grep docker.service"
     tests:
       test_items:
@@ -128,6 +133,7 @@ groups:
   - id: 1.9
     description: "Ensure auditing is configured for Docker files and directories -
     docker.socket (Scored)"
+    failed_description: "Show this if failed"
     audit: "auditctl -l | grep docker.socket"
     tests:
       test_items:
@@ -147,6 +153,7 @@ groups:
   - id: 1.10
     description: "Ensure auditing is configured for Docker files and directories -
     /etc/default/docker (Scored)"
+    failed_description: "Show this if failed"
     audit: "auditctl -l | grep /etc/default/docker"
     tests:
       test_items:
@@ -166,6 +173,7 @@ groups:
   - id: 1.11
     description: "Ensure auditing is configured for Docker files and directories -
     /etc/docker/daemon.json (Scored)"
+    failed_description: "Show this if failed"
     audit: "auditctl -l | grep /etc/docker/daemon.json"
     tests:
       test_items:
@@ -185,6 +193,7 @@ groups:
   - id: 1.12
     description: "Ensure auditing is configured for Docker files and directories -
     /usr/bin/docker-containerd (Scored)"
+    failed_description: "Show this if failed"
     audit: "auditctl -l | grep /usr/bin/docker-containerd"
     tests:
       test_items:
@@ -204,6 +213,7 @@ groups:
   - id: 1.13
     description: "Ensure auditing is configured for Docker files and directories -
     /usr/bin/docker-runc (Scored)"
+    failed_description: "Show this if failed"
     audit: "auditctl -l | grep /usr/bin/docker-runc"
     tests:
       test_items:
@@ -226,6 +236,7 @@ groups:
   - id: 2.1
     description: "Ensure network traffic is restricted between containers on the
     default bridge (Scored)"
+    failed_description: "Show this if failed"
     audit: "docker network ls --quiet | xargs docker network inspect --format '{{ .Name }}: {{ .Options }}'"
     tests:
       test_items:
@@ -246,6 +257,7 @@ groups:
 
   - id: 2.2
     description: "Ensure the logging level is set to 'info' (Scored)"
+    failed_description: "Show this if failed"
     audit: "ps -ef | grep docker"
     tests:
       bin_op: or
@@ -263,6 +275,7 @@ groups:
 
   - id: 2.3
     description: "Ensure Docker is allowed to make changes to iptables (Scored)"
+    failed_description: "Show this if failed"
     audit: "ps -ef | grep dockerd"
     tests:
       bin_op: or
@@ -282,6 +295,7 @@ groups:
 
   - id: 2.4
     description: "Ensure insecure registries are not used (Scored)"
+    failed_description: "Show this if failed"
     audit: "ps -ef | grep dockerd"
     tests:
       test_items:
@@ -295,6 +309,7 @@ groups:
 
   - id: 2.5
     description: "Ensure aufs storage driver is not used (Scored)"
+    failed_description: "Show this if failed"
     audit: docker info | grep -e "^Storage Driver:\s*aufs\s*$"
     tests:
       test_items:
@@ -311,6 +326,7 @@ groups:
 
   - id: 2.6
     description: "Ensure TLS authentication for Docker daemon is configured (Scored)"
+    failed_description: "Show this if failed"
     audit: ps -ef | grep dockerd
     tests:
       test_items:
@@ -343,6 +359,7 @@ groups:
 
   - id: 2.8
     description: "Enable user namespace support (Scored)"
+    failed_description: "Show this if failed"
     audit: docker info --format '{{ .SecurityOptions }}'
     tests:
       test_items:
@@ -365,6 +382,7 @@ groups:
 
   - id: 2.9
     description: "Ensure the default cgroup usage has been confirmed (Scored)"
+    failed_description: "Show this if failed"
     audit: ps -ef | grep dockerd
     tests:
       bin_op: or
@@ -385,6 +403,7 @@ groups:
 
   - id: 2.10
     description: "Ensure base device size is not changed until needed (Scored)"
+    failed_description: "Show this if failed"
     audit: ps -ef | grep dockerd
     tests:
       test_items:
@@ -397,6 +416,7 @@ groups:
   - id: 2.11
     description: "Ensure that authorization for Docker client commands is enabled
     (Scored)"
+    failed_description: "Show this if failed"
     audit: ps -ef | grep dockerd
     tests:
       test_items:
@@ -426,6 +446,7 @@ groups:
 
   - id: 2.13
     description: "Ensure operations on legacy registry (v1) are Disabled (Scored)"
+    failed_description: "Show this if failed"
     audit: ps -ef | grep dockerd
     tests:
       test_items:
@@ -438,6 +459,7 @@ groups:
 
   - id: 2.14
     description: "Ensure live restore is Enabled (Scored)"
+    failed_description: "Show this if failed"
     audit: ps -ef | grep dockerd
     tests:
       test_items:
@@ -451,6 +473,7 @@ groups:
 
   - id: 2.15
     description: "Ensure Userland Proxy is Disabled (Scored)"
+    failed_description: "Show this if failed"
     audit: ps -ef | grep dockerd
     tests:
       test_items:
@@ -467,6 +490,7 @@ groups:
   - id: 2.16
     description: "Ensure daemon-wide custom seccomp profile is applied, if needed
     (Not Scored)"
+    failed_description: "Show this if failed"
     audit: docker info --format '{{ .SecurityOptions }}'
     tests:
       test_items:
@@ -485,6 +509,7 @@ groups:
 
   - id: 2.17
     description: "Ensure experimental features are avoided in production (Scored)"
+    failed_description: "Show this if failed"
     audit: docker version --format '{{ .Server.Experimental }}'
     tests:
       test_items:
@@ -500,6 +525,7 @@ groups:
   - id: 2.18
     description: "Ensure containers are restricted from acquiring new privileges
     (Scored)"
+    failed_description: "Show this if failed"
     audit: ps -ef | grep dockerd
     tests:
       bin_op: or
@@ -521,6 +547,7 @@ groups:
   checks:
   - id: 3.1
     description: "Ensure that docker.service file ownership is set to root:root (Scored)"
+    failed_description: "Show this if failed"
     audit: systemctl show -p FragmentPath docker.service | cut -d= -f2 | xargs stat -c %U:%G
     tests:
       test_items:
@@ -542,6 +569,7 @@ groups:
   - id: 3.2
     description: "Ensure that docker.service file permissions are set to 644 or more
     restrictive (Scored)"
+    failed_description: "Show this if failed"
     audit: systemctl show -p FragmentPath docker.service | cut -d= -f2 | xargs stat -c %a
     tests:
       test_items:
@@ -561,6 +589,7 @@ groups:
 
   - id: 3.3
     description: "Ensure that docker.socket file ownership is set to root:root (Scored)"
+    failed_description: "Show this if failed"
     audit: systemctl show -p FragmentPath docker.socket | cut -d= -f2 | xargs stat -c %U:%G
     tests:
       test_items:
@@ -582,6 +611,7 @@ groups:
   - id: 3.4
     description: "Ensure that docker.socket file permissions are set to 644 or more
     restrictive (Scored)"
+    failed_description: "Show this if failed"
     audit: systemctl show -p FragmentPath docker.socket | cut -d= -f2 | xargs stat -c %a
     tests:
       test_items:
@@ -602,6 +632,7 @@ groups:
   - id: 3.5
     description: "Ensure that /etc/docker directory ownership is set to root:root
     (Scored)"
+    failed_description: "Show this if failed"
     audit: stat -c %U:%G /etc/docker
     tests:
       test_items:
@@ -618,6 +649,7 @@ groups:
   - id: 3.6
     description: "Ensure that /etc/docker directory permissions are set to 755 or more
     restrictive (Scored)"
+    failed_description: "Show this if failed"
     audit: stat -c %a /etc/docker
     tests:
       bin_op: or
@@ -645,6 +677,7 @@ groups:
   - id: 3.7
     description: "Ensure that registry certificate file ownership is set to root:root
     (Scored)"
+    failed_description: "Show this if failed"
     audit: /bin/sh -c "if [ -d /etc/docker/certs.d ]; then stat -c %U:%G /etc/docker/certs.d/*; fi"
     tests:
       test_items:
@@ -658,6 +691,7 @@ groups:
   - id: 3.8
     description: "Ensure that registry certificate file permissions are set to 444 or
     more restrictive (Scored)"
+    failed_description: "Show this if failed"
     audit: /bin/sh -c "if [ -d /etc/docker/certs.d ]; then stat -c %a /etc/docker/certs.d/*; fi"
     tests:
       test_items:
@@ -730,6 +764,7 @@ groups:
   - id: 3.15
     description: "Ensure that Docker socket file ownership is set to root:docker
     (Scored)"
+    failed_description: "Show this if failed"
     audit: /bin/sh -c "if [ -f /var/run/docker.sock ]; then stat -c %U:%G /var/run/docker.sock; fi"
     tests:
       test_items:
@@ -747,6 +782,7 @@ groups:
   - id: 3.16
     description: "Ensure that Docker socket file permissions are set to 660 or more
     restrictive (Scored)"
+    failed_description: "Show this if failed"
     audit: /bin/sh -c "if [ -f /var/run/docker.sock ]; then stat -c %a /var/run/docker.sock; fi"
     tests:
       bin_op: or
@@ -769,6 +805,7 @@ groups:
 
   - id: 3.17
     description: "Ensure that daemon.json file ownership is set to root:root (Scored)"
+    failed_description: "Show this if failed"
     audit: /bin/sh -c "if [ -f /etc/docker/daemon.json ]; then stat -c %U:%G /etc/docker/daemon.json; fi"
     tests:
       test_items:
@@ -785,6 +822,7 @@ groups:
   - id: 3.18
     description: "Ensure that daemon.json file permissions are set to 644 or more
     restrictive (Scored)"
+    failed_description: "Show this if failed"
     audit: /bin/sh -c "if [ -f /etc/docker/daemon.json ]; then stat -c %a /etc/docker/daemon.json; fi"
     tests:
       bin_op: or
@@ -812,6 +850,7 @@ groups:
   - id: 3.19
     description: "Ensure that /etc/default/docker file ownership is set to root:root
     (Scored)"
+    failed_description: "Show this if failed"
     audit: /bin/sh -c "if [ -f /etc/default/docker ]; then stat -c %U:%G /etc/default/docker; fi"
     tests:
       test_items:
@@ -828,6 +867,7 @@ groups:
   - id: 3.20
     description: "Ensure that /etc/default/docker file permissions are set to 644 or
     more restrictive (Scored)"
+    failed_description: "Show this if failed"
     audit: /bin/sh -c "if [ -f /etc/default/docker ]; then stat -c %a /etc/default/docker; fi"
     tests:
       bin_op: or
@@ -857,7 +897,8 @@ groups:
   checks:
   - id: 4.1
     description: "Ensure a user for the container has been created (Scored)"
-    audit: "docker ps --quiet --all | xargs docker inspect --format '{{ .Id }}: User={{ .Config.User }}'"
+    failed_description: "Show this if failed"
+    audit: "docker ps --quiet --all | xargs docker inspect --format 'Id$${{ .Id }},Name$${{ .Name }}: User={{ .Config.User }}'"
     tests:
       bin_op: and
       test_items:
@@ -933,6 +974,7 @@ groups:
     #### Come back here
   - id: 4.5
     description: "Ensure Content trust for Docker is Enabled (Scored)"
+    failed_description: "Show this if failed"
     audit: echo $DOCKER_CONTENT_TRUST
     tests:
       test_items:
@@ -1047,7 +1089,8 @@ groups:
 
   - id: 5.4
     description: "Ensure privileged containers are not used (Scored)"
-    audit: docker ps --quiet --all | xargs docker inspect --format '{{ .Id }}:Privileged={{ .HostConfig.Privileged }}'
+    failed_description: "Show this if failed"
+    audit: docker ps --quiet --all | xargs docker inspect --format 'Id$${{ .Id }},Name$${{ .Name }}:Privileged={{ .HostConfig.Privileged }}'
     tests:
       test_items:
       - flag: "Privileged=true"
@@ -1061,7 +1104,8 @@ groups:
   - id: 5.5
     description: "Ensure sensitive host system directories are not mounted on
     containers (Scored)"
-    audit: docker ps --quiet --all | xargs docker inspect --format '{{ .Id }}:Volumes={{ .Mounts }}'
+    failed_description: "Show this if failed"
+    audit: docker ps --quiet --all | xargs docker inspect --format 'Id$${{ .Id }},Name$${{ .Name }}:Volumes={{ .Mounts }}'
     tests:
       test_items:
       - flag: "Source:/ Destination"
@@ -1120,7 +1164,8 @@ groups:
 
   - id: 5.9
     description: "Ensure the host's network namespace is not shared (Scored)"
-    audit: docker ps --quiet --all | xargs docker inspect --format '{{ .Id }}:NetworkMode={{ .HostConfig.NetworkMode }}'
+    failed_description: "Show this if failed"
+    audit: docker ps --quiet --all | xargs docker inspect --format 'Id$${{ .Id }},Name$${{ .Name }}:NetworkMode={{ .HostConfig.NetworkMode }}'
     tests:
       test_items:
       - flag: "NetworkMode=host"
@@ -1131,7 +1176,8 @@ groups:
 
   - id: 5.10
     description: "Ensure memory usage for container is limited (Scored)"
-    audit: docker ps --quiet --all | xargs docker inspect --format '{{ .Id }}:Memory={{ .HostConfig.Memory }}'
+    failed_description: "Show this if failed"
+    audit: docker ps --quiet --all | xargs docker inspect --format 'Id$${{ .Id }},Name$${{ .Name }}:Memory={{ .HostConfig.Memory }}'
     tests:
       test_items:
       - flag: "Memory"
@@ -1156,7 +1202,8 @@ groups:
 
   - id: 5.11
     description: "Ensure CPU priority is set appropriately on the container (Scored)"
-    audit: docker ps --quiet --all | xargs docker inspect --format '{{ .Id }}:CpuShares={{ .HostConfig.CpuShares }}' 
+    failed_description: "Show this if failed"
+    audit: docker ps --quiet --all | xargs docker inspect --format 'Id$${{ .Id }},Name$${{ .Name }}:CpuShares={{ .HostConfig.CpuShares }}'
     tests:
       test_items:
       - flag: "CpuShares"
@@ -1184,7 +1231,8 @@ groups:
   - id: 5.12
     description: "Ensure the container's root filesystem is mounted as read only
     (Scored)"
-    audit: docker ps --quiet --all | xargs docker inspect --format '{{ .Id }}:ReadonlyRootfs={{ .HostConfig.ReadonlyRootfs }}'
+    failed_description: "Show this if failed"
+    audit: docker ps --quiet --all | xargs docker inspect --format 'Id$${{ .Id }},Name$${{ .Name }}:ReadonlyRootfs={{ .HostConfig.ReadonlyRootfs }}'
     tests:
       test_items:
       - flag: "ReadonlyRootfs=false"
@@ -1219,7 +1267,8 @@ groups:
   - id: 5.13
     description: "Ensure incoming container traffic is binded to a specific host
     interface (Scored)"
-    audit: docker ps --quiet | xargs docker inspect --format '{{ .Id }}:Ports={{ .NetworkSettings.Ports }}'
+    failed_description: "Show this if failed"
+    audit: docker ps --quiet | xargs docker inspect --format 'Id$${{ .Id }},Name$${{ .Name }}:Ports={{ .NetworkSettings.Ports }}'
     tests:
       test_items:
       - flag: "0.0.0.0"
@@ -1244,7 +1293,8 @@ groups:
 
   - id: 5.15
     description: "Ensure the host's process namespace is not shared (Scored)"
-    audit: docker ps --quiet --all | xargs docker inspect --format '{{ .Id }}:PidMode={{ .HostConfig.PidMode }}'
+    failed_description: "Show this if failed"
+    audit: docker ps --quiet --all | xargs docker inspect --format 'Id$${{ .Id }},Name$${{ .Name }}:PidMode={{ .HostConfig.PidMode }}'
     tests:
       test_items:
       - flag: "PidMode=host"
@@ -1257,7 +1307,8 @@ groups:
 
   - id: 5.16
     description: "Ensure the host's IPC namespace is not shared (Scored)"
-    audit: docker ps --quiet --all | xargs docker inspect --format '{{ .Id }}:IpcMode={{ .HostConfig.IpcMode }}'
+    failed_description: "Show this if failed"
+    audit: docker ps --quiet --all | xargs docker inspect --format 'Id$${{ .Id }},Name$${{ .Name }}:IpcMode={{ .HostConfig.IpcMode }}'
     tests:
       test_items:
       - flag: "IpcMode=host"
@@ -1305,7 +1356,8 @@ groups:
 
   - id: 5.20
     description: "Ensure the host's UTS namespace is not shared (Scored)"
-    audit: docker ps --quiet --all | xargs docker inspect --format '{{ .Id }}:UTSMode={{ .HostConfig.UTSMode }}'
+    failed_description: "Show this if failed"
+    audit: docker ps --quiet --all | xargs docker inspect --format 'Id$${{ .Id }},Name$${{ .Name }}:UTSMode={{ .HostConfig.UTSMode }}'
     tests:
       test_items:
       - flag: "UTSMode=host"
@@ -1318,7 +1370,8 @@ groups:
 
   - id: 5.21
     description: "Ensure the default seccomp profile is not Disabled (Scored)"
-    audit: docker ps --quiet --all | xargs docker inspect --format '{{ .Id }}:SecurityOpt={{ .HostConfig.SecurityOpt }}'
+    failed_description: "Show this if failed"
+    audit: docker ps --quiet --all | xargs docker inspect --format 'Id$${{ .Id }},Name$${{ .Name }}:SecurityOpt={{ .HostConfig.SecurityOpt }}'
     tests:
       test_items:
       - flag: "seccomp:unconfined"
@@ -1357,7 +1410,8 @@ groups:
   - id: 5.25
     description: "Ensure the container is restricted from acquiring additional
     privileges (Scored)"
-    audit: docker ps --quiet --all | xargs docker inspect --format '{{ .Id }}:SecurityOpt={{ .HostConfig.SecurityOpt }}'
+    failed_description: "Show this if failed"
+    audit: docker ps --quiet --all | xargs docker inspect --format 'Id$${{ .Id }},Name$${{ .Name }}:SecurityOpt={{ .HostConfig.SecurityOpt }}'
     tests:
       test_items:
       - flag: "no-new-privileges"
@@ -1390,7 +1444,8 @@ groups:
 
   - id: 5.28
     description: "Ensure PIDs cgroup limit is used (Scored)"
-    audit: docker ps --quiet --all | xargs docker inspect --format '{{ .Id }}:PidsLimit={{ .HostConfig.PidsLimit }}'
+    failed_description: "Show this if failed"
+    audit: docker ps --quiet --all | xargs docker inspect --format 'Id$${{ .Id }},Name$${{ .Name }}:PidsLimit={{ .HostConfig.PidsLimit }}'
     tests:
       test_items:
       - flag: "PidsLimit"
@@ -1409,7 +1464,8 @@ groups:
 
   - id: 5.29
     description: "Ensure Docker's default bridge docker0 is not used (Not Scored)"
-    audit: docker network ls --quiet | xargs xargs docker network inspect --format '{{ .Name }}:{{ .Options }}'
+    failed_description: "Show this if failed"
+    audit: docker network ls --quiet | xargs xargs docker network inspect --format 'Id$${{ .Id }},Name$${{ .Name }}:{{ .Options }}'
     tests:
       test_items:
       - flag: "com.docker.network.bridge.name:docker0"
@@ -1422,7 +1478,7 @@ groups:
     # Revisit: issue representing null value
   - id: 5.30
     description: "Ensure the host's user namespaces is not shared (Scored)"
-    audit: docker ps --quiet --all | xargs docker inspect --format '{{ .Id }}:UsernsMode={{ .HostConfig.UsernsMode }}'
+    audit: docker ps --quiet --all | xargs docker inspect --format 'Id$${{ .Id }},Name$${{ .Name }}:UsernsMode={{ .HostConfig.UsernsMode }}'
     type: manual
     tests:
       test_items:
@@ -1437,7 +1493,8 @@ groups:
   - id: 5.31
     description: "Ensure the Docker socket is not mounted inside any containers
     (Scored)"
-    audit: docker ps --quiet --all | xargs docker inspect --format '{{ .Id }}:Volumes={{ .Mounts }}' | grep docker.sock
+    failed_description: "Show this if failed"
+    audit: docker ps --quiet --all | xargs docker inspect --format 'Id$${{ .Id }},Name$${{ .Name }}:Volumes={{ .Mounts }}' | grep docker.sock
     tests:
       test_items:
       - flag: "docker.sock"
@@ -1505,6 +1562,7 @@ groups:
   - id: 7.3
     description: "Ensure swarm services are binded to a specific host interface
     (Scored)"
+    failed_description: "Show this if failed"
     audit: netstat -lt | grep -i 2377
     tests:
       test_items:
@@ -1519,7 +1577,8 @@ groups:
   - id: 7.4
     description: "Ensure data exchanged between containers are encrypted on
     different nodes on the overlay network (Scored)"
-    audit: docker network ls --filter driver=overlay --quiet | xargs docker network inspect --format '{{.Name}} {{ .Options }}'
+    failed_description: "Show this if failed"
+    audit: docker network ls --filter driver=overlay --quiet | xargs docker network inspect --format 'Id$${{ .Id }},Name$${{ .Name }}:{{ .Options }}'
     tests:
       test_items:
       - flag: "encrypted"
@@ -1538,6 +1597,7 @@ groups:
 
   - id: 7.6
     description: "Ensure swarm manager is run in auto-lock mode (Scored)"
+    failed_description: "Show this if failed"
     audit: docker swarm unlock-key
     tests:
       test_items:

--- a/cfg/17.06/definitions.yaml
+++ b/cfg/17.06/definitions.yaml
@@ -8,7 +8,7 @@ groups:
   checks:
   - id: 1.1
     description: "Ensure a separate partition for containers has been created (Scored)"
-    failed_description: "Show this if failed"
+    failed_description: "No separate partition for /var/lib/docker was found"
     audit: grep /var/lib/docker /etc/fstab
     tests:
       test_items:
@@ -51,7 +51,7 @@ groups:
 
   - id: 1.5
     description: "Ensure auditing is configured for the docker daemon (Scored)"
-    failed_description: "Show this if failed"
+    failed_description: "Auditing is not configured"
     audit: "auditctl -l | grep /usr/bin/docker"
     tests:
       test_items:
@@ -71,7 +71,7 @@ groups:
   - id: 1.6
     description: "Ensure auditing is configured for Docker files and directories - 
     /var/lib/docker (Scored)"
-    failed_description: "Show this if failed"
+    failed_description: "Auditing is not configured"
     audit: "auditctl -l | grep /var/lib/docker"
     tests:
       test_items:
@@ -91,7 +91,7 @@ groups:
   - id: 1.7
     description: "Ensure auditing is configured for Docker files and directories -
     /etc/docker (Scored)"
-    failed_description: "Show this if failed"
+    failed_description: "Auditing is not configured"
     audit: "auditctl -l | grep /etc/docker"
     tests:
       test_items:
@@ -112,7 +112,7 @@ groups:
   - id: 1.8
     description: "Ensure auditing is configured for Docker files and directories -
     docker.service (Scored)"
-    failed_description: "Show this if failed"
+    failed_description: "Auditing is not configured"
     audit: "auditctl -l | grep docker.service"
     tests:
       test_items:
@@ -133,7 +133,7 @@ groups:
   - id: 1.9
     description: "Ensure auditing is configured for Docker files and directories -
     docker.socket (Scored)"
-    failed_description: "Show this if failed"
+    failed_description: "Auditing is not configured"
     audit: "auditctl -l | grep docker.socket"
     tests:
       test_items:
@@ -153,7 +153,7 @@ groups:
   - id: 1.10
     description: "Ensure auditing is configured for Docker files and directories -
     /etc/default/docker (Scored)"
-    failed_description: "Show this if failed"
+    failed_description: "Auditing is not configured"
     audit: "auditctl -l | grep /etc/default/docker"
     tests:
       test_items:
@@ -173,7 +173,7 @@ groups:
   - id: 1.11
     description: "Ensure auditing is configured for Docker files and directories -
     /etc/docker/daemon.json (Scored)"
-    failed_description: "Show this if failed"
+    failed_description: "Auditing is not configured"
     audit: "auditctl -l | grep /etc/docker/daemon.json"
     tests:
       test_items:
@@ -193,7 +193,7 @@ groups:
   - id: 1.12
     description: "Ensure auditing is configured for Docker files and directories -
     /usr/bin/docker-containerd (Scored)"
-    failed_description: "Show this if failed"
+    failed_description: "Auditing is not configured"
     audit: "auditctl -l | grep /usr/bin/docker-containerd"
     tests:
       test_items:
@@ -213,7 +213,7 @@ groups:
   - id: 1.13
     description: "Ensure auditing is configured for Docker files and directories -
     /usr/bin/docker-runc (Scored)"
-    failed_description: "Show this if failed"
+    failed_description: "Auditing is not configured"
     audit: "auditctl -l | grep /usr/bin/docker-runc"
     tests:
       test_items:
@@ -236,7 +236,7 @@ groups:
   - id: 2.1
     description: "Ensure network traffic is restricted between containers on the
     default bridge (Scored)"
-    failed_description: "Show this if failed"
+    failed_description: "Docker network com.docker.network.bridge.enable_icc is set to true"
     audit: "docker network ls --quiet | xargs docker network inspect --format '{{ .Name }}: {{ .Options }}'"
     tests:
       test_items:
@@ -257,7 +257,7 @@ groups:
 
   - id: 2.2
     description: "Ensure the logging level is set to 'info' (Scored)"
-    failed_description: "Show this if failed"
+    failed_description: "Logging level is not info"
     audit: "ps -ef | grep docker"
     tests:
       bin_op: or
@@ -275,7 +275,7 @@ groups:
 
   - id: 2.3
     description: "Ensure Docker is allowed to make changes to iptables (Scored)"
-    failed_description: "Show this if failed"
+    failed_description: "Docker iptables is not allowed"
     audit: "ps -ef | grep dockerd"
     tests:
       bin_op: or
@@ -295,7 +295,7 @@ groups:
 
   - id: 2.4
     description: "Ensure insecure registries are not used (Scored)"
-    failed_description: "Show this if failed"
+    failed_description: "Docker is using insecure registries"
     audit: "ps -ef | grep dockerd"
     tests:
       test_items:
@@ -309,7 +309,7 @@ groups:
 
   - id: 2.5
     description: "Ensure aufs storage driver is not used (Scored)"
-    failed_description: "Show this if failed"
+    failed_description: "Docker daemon is running with aufs as storage driver"
     audit: docker info | grep -e "^Storage Driver:\s*aufs\s*$"
     tests:
       test_items:
@@ -326,7 +326,7 @@ groups:
 
   - id: 2.6
     description: "Ensure TLS authentication for Docker daemon is configured (Scored)"
-    failed_description: "Show this if failed"
+    failed_description: "TLS authentication for Docker daemon is not configured"
     audit: ps -ef | grep dockerd
     tests:
       test_items:
@@ -359,7 +359,7 @@ groups:
 
   - id: 2.8
     description: "Enable user namespace support (Scored)"
-    failed_description: "Show this if failed"
+    failed_description: "User namespace support is not enabled - userns not found"
     audit: docker info --format '{{ .SecurityOptions }}'
     tests:
       test_items:
@@ -382,7 +382,7 @@ groups:
 
   - id: 2.9
     description: "Ensure the default cgroup usage has been confirmed (Scored)"
-    failed_description: "Show this if failed"
+    failed_description: "Default cgroup usage is not confirmed"
     audit: ps -ef | grep dockerd
     tests:
       bin_op: or
@@ -403,7 +403,7 @@ groups:
 
   - id: 2.10
     description: "Ensure base device size is not changed until needed (Scored)"
-    failed_description: "Show this if failed"
+    failed_description: "Docker is set with storage optimization"
     audit: ps -ef | grep dockerd
     tests:
       test_items:
@@ -416,7 +416,7 @@ groups:
   - id: 2.11
     description: "Ensure that authorization for Docker client commands is enabled
     (Scored)"
-    failed_description: "Show this if failed"
+    failed_description: "Docker is not set with authorization-plugin"
     audit: ps -ef | grep dockerd
     tests:
       test_items:
@@ -446,7 +446,7 @@ groups:
 
   - id: 2.13
     description: "Ensure operations on legacy registry (v1) are Disabled (Scored)"
-    failed_description: "Show this if failed"
+    failed_description: "Docker daemon is not running with --disable-legacy-registry parameter"
     audit: ps -ef | grep dockerd
     tests:
       test_items:
@@ -459,7 +459,7 @@ groups:
 
   - id: 2.14
     description: "Ensure live restore is Enabled (Scored)"
-    failed_description: "Show this if failed"
+    failed_description: "Docker daemon is not running with --live-restore parameter"
     audit: ps -ef | grep dockerd
     tests:
       test_items:
@@ -473,7 +473,7 @@ groups:
 
   - id: 2.15
     description: "Ensure Userland Proxy is Disabled (Scored)"
-    failed_description: "Show this if failed"
+    failed_description: "Docker daemon is not running with --userland-proxy parameter"
     audit: ps -ef | grep dockerd
     tests:
       test_items:
@@ -509,7 +509,7 @@ groups:
 
   - id: 2.17
     description: "Ensure experimental features are avoided in production (Scored)"
-    failed_description: "Show this if failed"
+    failed_description: "Docker daemon is running with --experimental parameter"
     audit: docker version --format '{{ .Server.Experimental }}'
     tests:
       test_items:
@@ -525,7 +525,7 @@ groups:
   - id: 2.18
     description: "Ensure containers are restricted from acquiring new privileges
     (Scored)"
-    failed_description: "Show this if failed"
+    failed_description: "Docker daemon is not running with --no-new-privileges parameter"
     audit: ps -ef | grep dockerd
     tests:
       bin_op: or
@@ -547,7 +547,7 @@ groups:
   checks:
   - id: 3.1
     description: "Ensure that docker.service file ownership is set to root:root (Scored)"
-    failed_description: "Show this if failed"
+    failed_description: "The ownership of docker.service file (if exists) is not set to root"
     audit: systemctl show -p FragmentPath docker.service | cut -d= -f2 | xargs stat -c %U:%G
     tests:
       test_items:
@@ -569,7 +569,7 @@ groups:
   - id: 3.2
     description: "Ensure that docker.service file permissions are set to 644 or more
     restrictive (Scored)"
-    failed_description: "Show this if failed"
+    failed_description: "The permissions of docker.service file (if exists) are less restrictive than 644"
     audit: systemctl show -p FragmentPath docker.service | cut -d= -f2 | xargs stat -c %a
     tests:
       test_items:
@@ -589,7 +589,7 @@ groups:
 
   - id: 3.3
     description: "Ensure that docker.socket file ownership is set to root:root (Scored)"
-    failed_description: "Show this if failed"
+    failed_description: "The ownership of docker.socket file (if exists) is not set to root"
     audit: systemctl show -p FragmentPath docker.socket | cut -d= -f2 | xargs stat -c %U:%G
     tests:
       test_items:
@@ -611,7 +611,7 @@ groups:
   - id: 3.4
     description: "Ensure that docker.socket file permissions are set to 644 or more
     restrictive (Scored)"
-    failed_description: "Show this if failed"
+    failed_description: "The permissions of docker.socket file (if exists) are less restrictive than 644"
     audit: systemctl show -p FragmentPath docker.socket | cut -d= -f2 | xargs stat -c %a
     tests:
       test_items:
@@ -632,7 +632,7 @@ groups:
   - id: 3.5
     description: "Ensure that /etc/docker directory ownership is set to root:root
     (Scored)"
-    failed_description: "Show this if failed"
+    failed_description: "The ownership of /etc/docker (if exists) is not set to root"
     audit: stat -c %U:%G /etc/docker
     tests:
       test_items:
@@ -649,7 +649,7 @@ groups:
   - id: 3.6
     description: "Ensure that /etc/docker directory permissions are set to 755 or more
     restrictive (Scored)"
-    failed_description: "Show this if failed"
+    failed_description: "The permissions of /etc/docker (if exists) are less restrictive than 755"
     audit: stat -c %a /etc/docker
     tests:
       bin_op: or
@@ -677,7 +677,7 @@ groups:
   - id: 3.7
     description: "Ensure that registry certificate file ownership is set to root:root
     (Scored)"
-    failed_description: "Show this if failed"
+    failed_description: "The ownership of registry certificate file (if exists) is not set to root"
     audit: /bin/sh -c "if [ -d /etc/docker/certs.d ]; then stat -c %U:%G /etc/docker/certs.d/*; fi"
     tests:
       test_items:
@@ -691,7 +691,7 @@ groups:
   - id: 3.8
     description: "Ensure that registry certificate file permissions are set to 444 or
     more restrictive (Scored)"
-    failed_description: "Show this if failed"
+    failed_description: "The permissions of registry certificate file (if exists) are less restrictive than 444"
     audit: /bin/sh -c "if [ -d /etc/docker/certs.d ]; then stat -c %a /etc/docker/certs.d/*; fi"
     tests:
       test_items:
@@ -764,7 +764,7 @@ groups:
   - id: 3.15
     description: "Ensure that Docker socket file ownership is set to root:docker
     (Scored)"
-    failed_description: "Show this if failed"
+    failed_description: "The ownership of docker socket file (if exists) is not set to root:docker"
     audit: /bin/sh -c "if [ -f /var/run/docker.sock ]; then stat -c %U:%G /var/run/docker.sock; fi"
     tests:
       test_items:
@@ -782,7 +782,7 @@ groups:
   - id: 3.16
     description: "Ensure that Docker socket file permissions are set to 660 or more
     restrictive (Scored)"
-    failed_description: "Show this if failed"
+    failed_description: "The permissions of docker socket file (if exists) are less restrictive than 660"
     audit: /bin/sh -c "if [ -f /var/run/docker.sock ]; then stat -c %a /var/run/docker.sock; fi"
     tests:
       bin_op: or
@@ -805,7 +805,7 @@ groups:
 
   - id: 3.17
     description: "Ensure that daemon.json file ownership is set to root:root (Scored)"
-    failed_description: "Show this if failed"
+    failed_description: "The ownership of daemon.json file (if exists) is not set to root:docker"
     audit: /bin/sh -c "if [ -f /etc/docker/daemon.json ]; then stat -c %U:%G /etc/docker/daemon.json; fi"
     tests:
       test_items:
@@ -822,7 +822,7 @@ groups:
   - id: 3.18
     description: "Ensure that daemon.json file permissions are set to 644 or more
     restrictive (Scored)"
-    failed_description: "Show this if failed"
+    failed_description: "The permissions of daemon.json file (if exists) are less restrictive than 644"
     audit: /bin/sh -c "if [ -f /etc/docker/daemon.json ]; then stat -c %a /etc/docker/daemon.json; fi"
     tests:
       bin_op: or
@@ -850,7 +850,7 @@ groups:
   - id: 3.19
     description: "Ensure that /etc/default/docker file ownership is set to root:root
     (Scored)"
-    failed_description: "Show this if failed"
+    failed_description: "The ownership of daemon.json file (if exists) is not set to root:docker"
     audit: /bin/sh -c "if [ -f /etc/default/docker ]; then stat -c %U:%G /etc/default/docker; fi"
     tests:
       test_items:
@@ -867,7 +867,7 @@ groups:
   - id: 3.20
     description: "Ensure that /etc/default/docker file permissions are set to 644 or
     more restrictive (Scored)"
-    failed_description: "Show this if failed"
+    failed_description: "The permissions of daemon.json file (if exists) are less restrictive than 644"
     audit: /bin/sh -c "if [ -f /etc/default/docker ]; then stat -c %a /etc/default/docker; fi"
     tests:
       bin_op: or
@@ -974,7 +974,7 @@ groups:
     #### Come back here
   - id: 4.5
     description: "Ensure Content trust for Docker is Enabled (Scored)"
-    failed_description: "Show this if failed"
+    failed_description: "$DOCKER_CONTENT_TRUST is not set"
     audit: echo $DOCKER_CONTENT_TRUST
     tests:
       test_items:


### PR DESCRIPTION
This branch holds 3 features:
- Enabling the usage of the no remediations flag
- Adding a failed description field to the yaml file
- Changing the audit command in every test that has multiple outputs (for example containers with no privileges) so that the output could be parsed to objects.

Most of the functionality of this features is in a corresponding branch in the project bench-common. 
